### PR TITLE
Potential fix for code scanning alert no. 3: Overly permissive file permissions

### DIFF
--- a/tools/migrate.py
+++ b/tools/migrate.py
@@ -262,7 +262,7 @@ if __name__ == "__main__":
         f.write(build_script)
     
     # Make executable
-    os.chmod('tools/build.py', 0o755)
+    os.chmod('tools/build.py', 0o700)
     
     print("✅ Erstellt: tools/build.py")
 


### PR DESCRIPTION
Potential fix for [https://github.com/PaulLukasHuber/rdr2rp-business-file-form/security/code-scanning/3](https://github.com/PaulLukasHuber/rdr2rp-business-file-form/security/code-scanning/3)

To fix the issue, the file permissions should be restricted to the owner only. This can be achieved by changing the `os.chmod` call to use `0o700` instead of `0o755`. The `0o700` permission ensures that only the owner of the file can read, write, and execute it, which is more secure for an internal script like this.

The change will be made on line 265 of the file `tools/migrate.py`. No additional imports or dependencies are required to implement this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
